### PR TITLE
Add leadership sections and timeline

### DIFF
--- a/acercade.html
+++ b/acercade.html
@@ -96,6 +96,285 @@
             </div>
         </section>
 
+        <section class="comp-3-section py-5">
+            <div class="container">
+                <div class="row align-items-center">
+                    <!-- Columna de la imagen y nombre -->
+                    <div class="col-md-4 text-center mb-4">
+                        <img src="resources/arturo-samano.jpg" alt="Arturo Sámano Coronel" class="comp-3-profile-img">
+                        <h5 class="mt-3 comp-3-name">Mtro. Arturo Sámano Coronel</h5>
+                        <p class="comp-3-subtitle">Jefe de la División de Universidad Abierta,<br>Continua y a Distancia</p>
+                    </div>
+
+                    <!-- Columna de texto -->
+                    <div class="col-md-8">
+                        <!-- Acerca de -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-search"></i></div>
+                                <h5 class="mb-0 comp-3-title">Acerca de</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                La División de Universidad Abierta, Continua y a Distancia es responsable del Sistema
+                                Universidad Abierta y Educación a Distancia (SUAyED), el área de Educación Continua
+                                y el Centro de Lenguas. Su objetivo principal es extender los recursos didácticos por medio
+                                de las Tecnologías de la Información y de la Comunicación (TIC).
+                            </p>
+                        </div>
+
+                        <!-- Misión -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Misión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Formar profesionales para un entorno intercultural de excelencia académica.
+                            </p>
+                        </div>
+
+                        <!-- Visión -->
+                        <div>
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Visión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Ser líder en la preparación y posicionamiento de ciudadanos globales.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="comp-3-section py-5">
+            <div class="container">
+                <div class="row align-items-center">
+                    <!-- Columna de la imagen y nombre -->
+                    <div class="col-md-4 text-center mb-4">
+                        <img src="" alt="Lic. Carolina Chaparro Flores" class="comp-3-profile-img">
+                        <h5 class="mt-3 comp-3-name">Lic. Carolina Chaparro Flores</h5>
+                        <p class="comp-3-subtitle">Jefa del Sistema de Universidad Abierta<br>y Educación a Distancia FES Aragón</p>
+                    </div>
+
+                    <!-- Columna de texto -->
+                    <div class="col-md-8">
+                        <!-- Acerca de -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-search"></i></div>
+                                <h5 class="mb-0 comp-3-title">Acerca de</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                El Sistema de Universidad Abierta y Educación a Distancia (SUAyED) en la FES Aragón es responsable
+                                de coordinar y promover las modalidades educativas no escolarizadas, utilizando tecnologías
+                                innovadoras para facilitar el acceso a la educación superior con flexibilidad y calidad académica.
+                            </p>
+                        </div>
+
+                        <!-- Misión -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Misión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Ofrecer educación superior de calidad en modalidades abierta y a distancia, formando profesionales
+                                competentes mediante modelos educativos innovadores y tecnologías de vanguardia.
+                            </p>
+                        </div>
+
+                        <!-- Visión -->
+                        <div>
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Visión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Consolidarnos como un referente nacional en educación abierta y a distancia, reconocido por su
+                                excelencia académica, innovación pedagógica y compromiso con la inclusión educativa.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="comp-3-section py-5">
+            <div class="container">
+                <div class="row align-items-center">
+                    <!-- Columna de la imagen y nombre -->
+                    <div class="col-md-4 text-center mb-4">
+                        <img src="resources/jefe-centro-lenguas.png" alt="Lic. Víctor Andrés García-Cabral Martínez" class="comp-3-profile-img">
+                        <h5 class="mt-3 comp-3-name">Lic. Víctor Andrés García-Cabral Martínez</h5>
+                        <p class="comp-3-subtitle">Jefe del Centro de Lenguas Extranjeras<br>FES Aragón</p>
+                    </div>
+
+                    <!-- Columna de texto -->
+                    <div class="col-md-8">
+                        <!-- Acerca de -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-search"></i></div>
+                                <h5 class="mb-0 comp-3-title">Acerca de</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                El Centro de Lenguas Extranjeras de la FES Aragón ofrece programas de enseñanza de idiomas con estándares internacionales,
+                                fomentando la competencia comunicativa y multicultural en los estudiantes. Nuestros cursos están diseñados para
+                                cubrir desde niveles básicos hasta avanzados, con enfoque en la certificación y aplicación práctica.
+                            </p>
+                        </div>
+
+                        <!-- Misión -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Misión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Formar profesionales con dominio de lenguas extranjeras, mediante programas académicos de calidad que impulsen
+                                la movilidad internacional, la competitividad laboral y el entendimiento intercultural.
+                            </p>
+                        </div>
+
+                        <!-- Visión -->
+                        <div>
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Visión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Ser un referente en la enseñanza de idiomas, reconocido por su excelencia académica,
+                                innovación pedagógica y contribución a la formación de ciudadanos globales con habilidades lingüísticas certificadas.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="comp-3-section py-5">
+            <div class="container">
+                <div class="row align-items-center">
+                    <!-- Columna de la imagen y nombre -->
+                    <div class="col-md-4 text-center mb-4">
+                        <img src="resources/jefe-educacion-continua.jpg" alt="M. en A. Isabel Chávez Hernández" class="comp-3-profile-img">
+                        <h5 class="mt-3 comp-3-name">M. en A. Isabel Chávez Hernández</h5>
+                        <p class="comp-3-subtitle">Jefe de Educación Continua<br>FES Aragón</p>
+                    </div>
+
+                    <!-- Columna de texto -->
+                    <div class="col-md-8">
+                        <!-- Acerca de -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-search"></i></div>
+                                <h5 class="mb-0 comp-3-title">Acerca de</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                El área de Educación Continua de la FES Aragón está comprometida con la actualización y especialización
+                                profesional a través de programas flexibles y de calidad. Ofrecemos cursos, diplomados y talleres
+                                diseñados para responder a las necesidades del mercado laboral y promover el desarrollo profesional
+                                continuo en diversas disciplinas.
+                            </p>
+                        </div>
+
+                        <!-- Misión -->
+                        <div class="mb-4">
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Misión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Brindar oportunidades de formación continua que fortalezcan las competencias profesionales
+                                y técnicas de nuestros participantes, mediante programas educativos innovadores y alineados
+                                con las demandas actuales de la sociedad y el sector productivo.
+                            </p>
+                        </div>
+
+                        <!-- Visión -->
+                        <div>
+                            <div class="d-flex align-items-center">
+                                <div class="comp-3-icon-circle"><i class="bi bi-check2-circle"></i></div>
+                                <h5 class="mb-0 comp-3-title">Visión</h5>
+                            </div>
+                            <p class="mt-2 comp-3-text">
+                                Posicionarnos como líderes en educación continua, siendo reconocidos por nuestra oferta académica
+                                de vanguardia, flexibilidad educativa y contribución al desarrollo profesional de nuestros egresados,
+                                impactando positivamente en su crecimiento laboral y personal.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Linea del tiempo -->
+        <section class="timeline-container">
+            <h2 class="timeline-title">Nuestra Historia de Eventos</h2>
+            <div class="timeline-line"></div>
+
+            <div class="timeline-event">
+                <div class="timeline-content left">
+                    <div class="timeline-year">2016</div>
+                    <img src="resources/banner_duacyd.JPG" alt="Evento 2016" class="timeline-image" loading="lazy">
+                </div>
+                <div class="timeline-marker"></div>
+                <div class="timeline-content right">
+                    <div class="timeline-text">
+                        <h3>Congreso Internacional</h3>
+                        <p>"Abriendo la UNAM: Tecnologías para la Educación y Sinergias Institucionales". Un evento pionero
+                            que marcó el inicio de nuestra trayectoria en innovación educativa.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="timeline-event">
+                <div class="timeline-content left">
+                    <div class="timeline-text">
+                        <h3>Innovación Educativa</h3>
+                        <p>Segundo Congreso Internacional con énfasis en tecnologías emergentes, donde exploramos las
+                            últimas tendencias en pedagogía digital.</p>
+                    </div>
+                </div>
+                <div class="timeline-marker"></div>
+                <div class="timeline-content right">
+                    <div class="timeline-year">2017</div>
+                    <img src="resources/banner_duacyd_alt.JPG" alt="Evento 2017" class="timeline-image" loading="lazy">
+                </div>
+            </div>
+
+            <div class="timeline-event">
+                <div class="timeline-content left">
+                    <div class="timeline-year">2018</div>
+                    <img src="resources/banner_duacyd.JPG" alt="Evento 2018" class="timeline-image" loading="lazy">
+                </div>
+                <div class="timeline-marker"></div>
+                <div class="timeline-content right">
+                    <div class="timeline-text">
+                        <h3>Educación 4.0</h3>
+                        <p>Tercer Congreso Internacional enfocado en la transformación digital de instituciones educativas,
+                            preparándonos para la cuarta revolución industrial.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="timeline-event">
+                <div class="timeline-content left">
+                    <div class="timeline-text">
+                        <h3>Desarrollo Sostenible</h3>
+                        <p>Cuarto Congreso Internacional que vinculó innovación educativa con los Objetivos de Desarrollo
+                            Sostenible de la ONU.</p>
+                    </div>
+                </div>
+                <div class="timeline-marker"></div>
+                <div class="timeline-content right">
+                    <div class="timeline-year">2019</div>
+                    <img src="resources/banner_duacyd.JPG" alt="Evento 2019" class="timeline-image" loading="lazy">
+                </div>
+            </div>
+        </section>
 
         <!-- Botones flotantes -->
         <div class="social-floating-buttons">
@@ -314,6 +593,41 @@
                     });
                 });
             }
+        });
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const observerOptions = {
+                threshold: 0.1,
+                rootMargin: '0px 0px -150px 0px'
+            };
+
+            const observerCallback = (entries, observer) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('active');
+                        observer.unobserve(entry.target);
+                    }
+                });
+            };
+
+            const observer = new IntersectionObserver(observerCallback, observerOptions);
+
+            document.querySelectorAll('.timeline-event').forEach((event, index) => {
+                event.style.transitionDelay = `${index * 0.15}s`;
+                observer.observe(event);
+            });
+
+            const timelineContents = document.querySelectorAll('.timeline-content');
+            timelineContents.forEach(content => {
+                content.addEventListener('mouseenter', () => {
+                    content.style.transform = 'translateY(-8px)';
+                    content.style.boxShadow = '0 20px 40px rgba(0, 0, 0, 0.15)';
+                });
+                content.addEventListener('mouseleave', () => {
+                    content.style.transform = 'translateY(0)';
+                    content.style.boxShadow = '0 10px 30px var(--shadow-color)';
+                });
+            });
         });
     </script>
     <!-- Bootstrap JS -->


### PR DESCRIPTION
## Summary
- add leadership profile sections for DUACyD division, SUAyED, CLE, and Educación Continua
- introduce historical timeline of major events
- enhance page script with intersection observer animation for timeline

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af978177588322b3457d937db68577