### PR TITLE
Use page-specific titles for DUACyD site

### DIFF
--- a/acercade.html
+++ b/acercade.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Conoce la misión, visión y al equipo de la DUACyD FES Aragón que impulsa la educación abierta, continua y a distancia.">
     <meta name="keywords" content="DUACyD, equipo, misión, visión, UNAM, FES Aragón">
-    <title>DUACyD FES Aragón</title>
+    <title>Acerca de | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">

--- a/contacto.html
+++ b/contacto.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Ponte en contacto con la DUACyD FES Aragón mediante nuestros canales oficiales para resolver dudas y recibir orientación.">
     <meta name="keywords" content="contacto, DUACyD, UNAM, FES Aragón, teléfono, correo">
-    <title>DUACyD FES Aragón</title>
+    <title>Contacto | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">

--- a/creditos.html
+++ b/creditos.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Reconocimiento al equipo de la DUACyD FES Aragón responsable del diseño y desarrollo de este sitio web.">
     <meta name="keywords" content="créditos, equipo, desarrollo web, DUACyD, UNAM, FES Aragón">
-    <title>DUACyD FES Aragón</title>
+    <title>Créditos | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="División de Universidad Abierta, Continua y a Distancia de la FES Aragón, programas flexibles y recursos educativos para tu formación.">
     <meta name="keywords" content="DUACyD, UNAM, FES Aragón, educación, programas, distancia">
-    <title>DUACyD FES Aragón</title>
+    <title>Inicio | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
@@ -181,7 +181,6 @@
                     diversas
                     jefaturas de
                     la DUACyD</h2>
-                </h2>
                 <p class="text-center mb-4 text-white">Explora nuestras diversas jefaturas y descubre cómo podemos
                     ayudarte
                     a

--- a/oferta-educativa.html
+++ b/oferta-educativa.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explora la oferta educativa de la DUACyD: modalidades SUAyED, educación continua y lenguas extranjeras para impulsar tu desarrollo.">
     <meta name="keywords" content="SUAyED, educación continua, idiomas, cursos, licenciaturas, DUACyD">
-    <title>DUACyD FES Aragón</title>
+    <title>Oferta Educativa | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">

--- a/pagina-construccion.html
+++ b/pagina-construccion.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Sección en desarrollo de la DUACyD FES Aragón; pronto encontrarás información y recursos actualizados.">
     <meta name="keywords" content="página en construcción, DUACyD, UNAM, FES Aragón, próximamente">
-    <title>DUACyD FES Aragón</title>
+    <title>Página en Construcción | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">

--- a/preguntas-frecuentes.html
+++ b/preguntas-frecuentes.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Respuestas claras a las dudas más comunes sobre la DUACyD, trámites, modalidades y servicios de la FES Aragón.">
     <meta name="keywords" content="preguntas frecuentes, FAQ, trámites, DUACyD, modalidades, servicios">
-    <title>DUACyD FES Aragón</title>
+    <title>Preguntas Frecuentes | DUACyD FES Aragón</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Set unique `<title>` values for all HTML pages using the format `<tema> | DUACyD FES Aragón`
- Fix stray `</h2>` tag in home page identified by `htmlhint`

## Testing
- `npx -y htmlhint *.html`

------
https://chatgpt.com/codex/tasks/task_e_68bdf9ca0e3c832294dd90a04f5b6b40